### PR TITLE
Chrome-like tabs

### DIFF
--- a/src/iframe.css
+++ b/src/iframe.css
@@ -1,0 +1,8 @@
+/*
+  Remove the bottom border for plugin iframes,
+  such that the tabs can "connect" to the rest of Joplin's UI.
+*/
+
+iframe {
+    border-bottom: none !important;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,11 @@ joplin.plugins.register({
     // panel
     const panel = new Panel(tabs, settings);
     await panel.register();
+    // custom CSS (to disable iframe border)
+    // source: https://github.com/andrejilderda/joplin-macos-native-theme/blob/main/src/index.ts#LL22C5-L22C5
+    const installDir = await joplin.plugins.installationDir();
+		const cssFilePath = installDir + '/iframe.css';
+    await (joplin as any).window.loadChromeCssFile(cssFilePath);
 
     //#region HELPERS
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -32,7 +32,8 @@ export enum UnpinBehavior {
 
 export enum LayoutMode {
   Auto,
-  Horizontal,
+  HorizontalTop,
+  HorizontalBottom,
   Vertical
 }
 
@@ -54,7 +55,7 @@ export class Settings {
   private _unpinBehavior: UnpinBehavior = UnpinBehavior.Keep;
   private _layoutMode: number = LayoutMode.Auto;
   // advanced settings
-  private _tabHeight: number = 35;
+  private _tabHeight: number = 30;
   private _minTabWidth: number = 50;
   private _maxTabWidth: number = 150;
   private _breadcrumbsMaxWidth: number = 100;
@@ -298,8 +299,9 @@ export class Settings {
         description: 'Force tabs horizontal or vertical layout. If Auto, the layout switches automatically at a width of about 400px. Requires restart to be applied.',
         options: {
           '0': 'Auto',
-          '1': 'Horizontal',
-          '2': 'Vertical'
+          '1': 'Horizontal (tabs above)',
+          '2': 'Horizontal (tabs below)',
+          '3': 'Vertical'
         }
       },
       // advanced settings

--- a/src/webview.css
+++ b/src/webview.css
@@ -9,15 +9,20 @@ body > div,
 div#joplin-plugin-content {
   height: 100%;
 }
+
 a {
   text-decoration: none;
 }
+
 span {
   cursor: default;
 }
 
 /* HORIZONTAL LAYOUT */
 #container {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
   height: 100%;
   overflow-x: hidden;
   overflow-y: overlay;
@@ -26,40 +31,69 @@ span {
 
 #tabs-container {
   display: flex;
+  align-items: flex-end;
+  flex-grow: 1;
+  /*padding: 0px 5px 0 5px;*/
   float: left;
   overflow-x: overlay;
+  overflow-y: hidden;
   width: 100%;
 }
+
 #tab {
-  border-style: solid;
-  border-width: 0;
-  border-right-width: 1px;
   display: flex;
+  position: relative;
   padding: 0 8px;
   transition: 0.2s;
+  flex-grow: 1;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
 }
+
 #tab .fas {
   margin-left: auto;
   margin-right: 0;
   padding: 2px;
-  visibility: hidden;
 }
-#tab:hover .fas {
-  visibility: visible;
+
+#tab[active]:before,
+#tab[active]:after {
+  position: absolute;
+  bottom: -1px;
+  width: 6px;
+  height: 6px;
+  content: " ";
+  transition: 0.2s;
 }
+
+#tab[active]:before {
+  z-index: 1;
+  left: -6px;
+  border-bottom-right-radius: 6px;
+}
+
+#tab[active]:after {
+  z-index: 1;
+  right: -6px;
+  border-bottom-left-radius: 6px;
+}
+
 .new {
   font-style: italic;
 }
+
 .tab-inner {
   align-items: center;
   display: flex;
   height: 100%;
   width: 100%;
 }
-.tab-inner > input {
+
+.tab-inner>input {
   margin: 0;
   margin-right: 3px;
 }
+
 .tab-title {
   overflow: hidden;
   padding-right: 3px;
@@ -75,6 +109,7 @@ span {
   margin-left: auto;
   margin-right: 0;
 }
+
 #controls .fas {
   align-items: center;
   display: flex;
@@ -86,6 +121,7 @@ span {
   opacity: 0.8;
   width: 26px;
 }
+
 #controls .fas:hover {
   opacity: 1;
 }
@@ -96,9 +132,11 @@ span {
   height: var(--infobarHeight);
   width: 100%;
 }
+
 #infobar-container .fas {
   font-size: 1.3em;
 }
+
 #infobar-container .fas.fa-book {
   font-size: 1.2em;
 }
@@ -111,10 +149,12 @@ span {
   min-width: fit-content;
   padding: 0 4px;
 }
+
 .navigation-icons a:hover {
   background: var(--joplin-background-color-hover3);
   border-radius: 3px;
 }
+
 .navigation-icons .fas {
   line-height: calc(var(--infobarHeight) - 2px);
   min-width: 12px;
@@ -129,20 +169,24 @@ span {
   min-width: fit-content;
   padding: 0 4px;
 }
+
 .checklist-state-inner {
   align-items: center;
   display: flex;
   line-height: calc(var(--infobarHeight) - 2px);
 }
+
 .checklist-state-text {
   align-items: center;
   display: flex;
   margin: 0 2px;
   padding: 0 4px;
 }
-.checklist-state-text > .fas {
+
+.checklist-state-text>.fas {
   padding-right: 4px;
 }
+
 .checklist-state-text.completed {
   background: #46ba61;
   color: white;
@@ -153,6 +197,7 @@ span {
   margin: auto 0;
   padding-left: 8px;
 }
+
 #breadcrumbs-container {
   display: flex;
   float: left;
@@ -160,28 +205,34 @@ span {
   overflow-y: hidden;
   width: 100%;
 }
+
 .breadcrumb {
   display: flex;
   height: var(--infobarHeight);
   min-width: 36px;
 }
+
 .breadcrumb:last-of-type .fas {
   display: none;
 }
+
 .breadcrumb-inner {
   align-items: center;
   display: flex;
   line-height: calc(var(--infobarHeight) - 2px);
   width: 100%;
 }
+
 .breadcrumb-inner a:hover {
   background: var(--joplin-background-color-hover3);
   border-radius: 3px;
 }
+
 .breadcrumb-inner .fas {
   margin-left: auto;
   margin-right: 0px;
 }
+
 .breadcrumb-title {
   margin: 0 2px;
   overflow: hidden;
@@ -206,6 +257,7 @@ span {
   height: 4px;
   width: 7px;
 }
+
 ::-webkit-scrollbar-thumb {
   background: rgba(0, 0, 0, 0.2);
   border-radius: 5px;

--- a/src/webview_auto.css
+++ b/src/webview_auto.css
@@ -3,12 +3,20 @@
   #tabs-container {
     display: block;
     height: 100%;
+    padding: 0;
   }
 
   #tab {
     border-right-width: 0;
     border-bottom-width: 1px;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
     max-width: 100% !important;
+  }
+
+  #tab[active]:before,
+  #tab[active]:after {
+    visibility: hidden;
   }
 
   #breadcrumbs-container {

--- a/src/webview_horizontal_bottom.css
+++ b/src/webview_horizontal_bottom.css
@@ -1,0 +1,33 @@
+/*
+  If the user places the tabs on the bottom,
+  we want to make the tabs connect to the upper border instead.
+*/
+
+#container {
+  align-items: flex-start;
+}
+
+#tabs-container {
+  align-items: flex-start;
+}
+
+#tab {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  border-bottom-left-radius: 8px;
+  border-bottom-right-radius: 8px;
+}
+
+#tab[active]:before {
+  top: 0;
+  left: -6px;
+  border-top-right-radius: 6px;
+  border-bottom-right-radius: 0;
+}
+
+#tab[active]:after {
+  top: 0;
+  right: -6px;
+  border-top-left-radius: 6px;
+  border-bottom-left-radius: 0;
+}

--- a/src/webview_vertical.css
+++ b/src/webview_vertical.css
@@ -2,12 +2,20 @@
 #tabs-container {
   display: block;
   height: 100%;
+  padding: 0;
 }
 
 #tab {
   border-right-width: 0;
   border-bottom-width: 1px;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
   max-width: 100% !important;
+}
+
+#tab[active]:before,
+#tab[active]:after {
+  visibility: hidden;
 }
 
 #breadcrumbs-container {


### PR DESCRIPTION
This PR changes the tab style to (more-or-less) resemble Chrome's tabs.
This is more of an aesthetic change and personal preference, but it also changes the CSS such that the tabs are always placed at the bottom (or top, configurable) of the plugin panel.

## Changes
- Adds a chrome-like style to the tabs
    - Adds rounded corners, and bend out rounded corners based on this web article: [(Better) Tabs with Round Out Borders](https://css-tricks.com/better-tabs-with-round-out-borders/)
    - Pin/Unpin button is always visible.
    - Adds code to make sure that the rounded out borders have the correct color, as configurable through the settings.
    - Tabs automatically grow to the maximum size (150px width by default), and shrink if space is limited.
- Removes iframe borders, such that the tabs can seamlessly "connect" to the rest of Joplin's UI.
- Changed the "Force tabs layout" options:
    - Replaced "Horizontal" option with "Horizontal (tabs above)" and "Horizontal (tabs below)".
- Changed the default of "Note Tabs height (px)" from 35 to 30.
- Breadcrumbs are placed above the tabs now when "Horizontal (tabs below)" is selected in the settings.

## Screenshots

![Bildschirmfoto vom 2023-05-02 10-05-37](https://user-images.githubusercontent.com/47528453/235612809-d4ce33ff-eb0e-4690-9d28-695051684c0a.png)
> Three tabs on top, Joplin's light theme

![Bildschirmfoto vom 2023-05-02 09-33-41](https://user-images.githubusercontent.com/47528453/235612034-e2be6206-0241-4be9-9280-10a9d3995476.png)
> Two tabs on top + Breadcrumbs, custom Catppuccin theme

![Bildschirmfoto vom 2023-05-02 09-07-31](https://user-images.githubusercontent.com/47528453/235610503-b230a06a-f784-4c42-be44-5abbe451c20c.png)
> Two tabs at bottom + Breadcrumbs, Joplin's dark theme

![Bildschirmfoto vom 2023-05-02 09-36-36](https://user-images.githubusercontent.com/47528453/235612189-2959fa0a-4e88-43ff-8810-ed8f5402a8ab.png)
> Vertical tabs still work as intended ("Auto" and "Vertical")
