### PR TITLE
fix: change "remove" to "close"

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,17 +86,17 @@ By default the panel will be on the right side of the screen, this can be adjust
 
 This plugin provides additional commands as described in the following table.
 
-| Command Label             | Command ID             | Description                                                                                   | Menu contexts                                                       |
-| ------------------------- | ---------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| Pin note to Tabs          | `tabsPinNote`          | Pin selected note(s) to the tabs.                                                             | `Tools>Tabs`, `NoteListContext`, `EditorContext`, `Command palette` |
-| Unpin note from Tabs      | `tabsUnpinNote`        | Unpin selected note(s) from the tabs.                                                         | `Tools>Tabs`, `Command palette`                                     |
-| Switch to last active Tab | `tabsSwitchLastActive` | Switch to the last active tab, i.e. to previous selected note.                                | `Tools>Tabs`, `Command palette`                                     |
-| Switch to left Tab        | `tabsSwitchLeft`       | Switch to the left tab next to the active, i.e. select the left note.                         | `Tools>Tabs`, `Command palette`                                     |
-| Switch to right Tab       | `tabsSwitchRight`      | Switch to the right tab next to the active, i.e. select the right note.                       | `Tools>Tabs`, `Command palette`                                     |
-| Move active Tab left      | `tabsMoveLeft`         | Move active tab one position to the left.                                                     | `Tools>Tabs`, `Command palette`                                     |
-| Move active Tab right     | `tabsMoveRight`        | Move active tab one position to the right.                                                    | `Tools>Tabs`, `Command palette`                                     |
-| Remove all pinned Tabs    | `tabsClear`            | Remove all pinned tabs. In case no note is selected, the tabs list might be empty afterwards. | `Tools>Tabs`, `Command palette`                                     |
-| Toggle Tabs visibility    | `tabsToggleVisibility` | Toggle panel visibility.                                                                      | `Tools>Tabs`, `Command palette`                                     |
+| Command Label             | Command ID             | Description                                                                                  | Menu contexts                                                       |
+| ------------------------- | ---------------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| Pin note to Tabs          | `tabsPinNote`          | Pin selected note(s) to the tabs.                                                            | `Tools>Tabs`, `NoteListContext`, `EditorContext`, `Command palette` |
+| Unpin note from Tabs      | `tabsUnpinNote`        | Unpin selected note(s) from the tabs.                                                        | `Tools>Tabs`, `Command palette`                                     |
+| Switch to last active Tab | `tabsSwitchLastActive` | Switch to the last active tab, i.e. to previous selected note.                               | `Tools>Tabs`, `Command palette`                                     |
+| Switch to left Tab        | `tabsSwitchLeft`       | Switch to the left tab next to the active, i.e. select the left note.                        | `Tools>Tabs`, `Command palette`                                     |
+| Switch to right Tab       | `tabsSwitchRight`      | Switch to the right tab next to the active, i.e. select the right note.                      | `Tools>Tabs`, `Command palette`                                     |
+| Move active Tab left      | `tabsMoveLeft`         | Move active tab one position to the left.                                                    | `Tools>Tabs`, `Command palette`                                     |
+| Move active Tab right     | `tabsMoveRight`        | Move active tab one position to the right.                                                   | `Tools>Tabs`, `Command palette`                                     |
+| Close all pinned Tabs     | `tabsClear`            | Close all pinned tabs. In case no note is selected, the tabs list might be empty afterwards. | `Tools>Tabs`, `Command palette`                                     |  |
+| Toggle Tabs visibility    | `tabsToggleVisibility` | Toggle panel visibility.                                                                     | `Tools>Tabs`, `Command palette`                                     |
 
 ### Keyboard shortcuts
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,7 @@ joplin.plugins.register({
       if (lastActiveNote.length < 2) return false;
 
       const lastActiveNoteId = lastActiveNote.id;
-      // return if an already removed tab is about to be restored
+      // return if an already closed tab is about to be restored
       if (tabs.indexOf(lastActiveNoteId) < 0) return false;
 
       await COMMANDS.execute('openNote', lastActiveNoteId);
@@ -108,9 +108,9 @@ joplin.plugins.register({
     }
 
     /**
-     * Remove or unpin note with handled id.
+     * Close or unpin note with handled id.
      */
-    async function removeTab(noteId: string) {
+    async function closeTab(noteId: string) {
       const selectedNote: any = await WORKSPACE.selectedNote();
 
       // if noteId is the selected note - try to select another note depending on the settings
@@ -136,17 +136,17 @@ joplin.plugins.register({
             break;
         }
 
-        // then remove note from tabs
+        // then delete note from tabs
         await tabs.delete(noteId);
 
         // if no one was selected before
         if (!selected) {
-          // re-add removed note as tab at the end
+          // re-add deleted note as tab at the end
           await addTab(noteId);
         }
       } else {
 
-        // else simply remove note from tabs
+        // else simply delete note from tabs
         await tabs.delete(noteId);
       }
     }
@@ -191,7 +191,7 @@ joplin.plugins.register({
 
         // unpin selected notes and update panel
         for (const noteId of selectedNoteIds) {
-          await removeTab(noteId);
+          await closeTab(noteId);
         }
         await panel.updateWebview();
       }
@@ -279,14 +279,14 @@ joplin.plugins.register({
     });
 
     // Command: tabsClear
-    // Desc: Remove all pinned tabs
+    // Desc: Close all pinned tabs
     await COMMANDS.register({
       name: 'tabsClear',
-      label: 'Remove all pinned Tabs',
+      label: 'Close all pinned Tabs',
       iconName: 'fas fa-times',
       execute: async () => {
         // ask user before removing tabs
-        const result: number = await DIALOGS.showMessageBox('Do you really want to remove all pinned tabs?');
+        const result: number = await DIALOGS.showMessageBox('Do you really want to close all pinned tabs?');
         if (result) return;
 
         await settings.clearTabs();
@@ -345,7 +345,7 @@ joplin.plugins.register({
       },
       {
         commandName: 'tabsClear',
-        label: 'Remove all pinned Tabs'
+        label: 'Close all pinned Tabs'
       },
       {
         commandName: 'tabsToggleVisibility',
@@ -410,13 +410,13 @@ joplin.plugins.register({
               const index: number = tabs.indexOf(note.id);
               // and the note is currently pinned...
               if (tabs.indexOfTemp != index) {
-                // then remove its tab
-                await removeTab(note.id);
+                // then close its tab
+                await closeTab(note.id);
               }
             }
           }
 
-          // note was deleted (ItemChangeEventType.Delete) - remove tab
+          // note was deleted (ItemChangeEventType.Delete) - delete tab
           if (ev.event == 3) {
             await tabs.delete(ev.id);
           }

--- a/src/noteTabs.ts
+++ b/src/noteTabs.ts
@@ -174,7 +174,7 @@ export class NoteTabs {
   }
 
   /**
-   * Removes tab on handled index.
+   * Deletes tab on handled index.
    */
   async delete(noteId: string) {
     const index = this.indexOf(noteId);

--- a/src/panel.ts
+++ b/src/panel.ts
@@ -148,7 +148,7 @@ export class Panel {
     for (const noteTab of this.tabs.tabs) {
       let note: any = null;
 
-      // get real note from database, if no longer exists remove tab and continue with next one
+      // get real note from database, if no longer exists delete tab and continue with next one
       try {
         note = await joplin.data.get(['notes', noteTab.id], { fields: ['id', 'title', 'is_todo', 'todo_completed'] });
         // console.log(`add note: ${JSON.stringify(note)}`);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -255,7 +255,7 @@ export class Settings {
         public: true,
         label: 'Automatically unpin completed to-dos',
         description: 'Unpin notes automatically as soon as the to-do status changes to completed. ' +
-          'Removes the tab completely unless it is the selected note.'
+          'Closes the tab unless it is the selected note.'
       },
       addBehavior: {
         value: AddBehavior.Temporary,


### PR DESCRIPTION
* rename `removeTab()` to `closeTab`
* Fix strings and comments wording

/closes Change all occurences of "remove" to "close" (#56)